### PR TITLE
Mount routes under /api/agent

### DIFF
--- a/src/api/routes.go
+++ b/src/api/routes.go
@@ -19,11 +19,6 @@ import (
 	"vnm/agent-info-service/spacetraders/schema"
 )
 
-// @title Agent Info Service API
-// @version 1.0
-// @description Service for accessing information about the agent - profile, fleet, contracts.
-// @BasePath /
-
 type CurrentAgentResponse struct {
 	Agent     schema.Agent      `json:"agent"`
 	Ships     []schema.Ship     `json:"ships"`
@@ -49,19 +44,21 @@ func SetUpRouter(conn *sql.DB) *mux.Router {
 	// never calls this handler, but a route has to exist here for OPTIONS to match at all.
 	r.Methods(http.MethodOptions).HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
 
-	r.HandleFunc("/current-agent", h.getCurrentAgent).Methods(http.MethodGet)
-	r.HandleFunc("/agent", h.getAgent).Methods(http.MethodGet)
-	r.HandleFunc("/ships", h.getShips).Methods(http.MethodGet)
-	r.HandleFunc("/ships/{shipSymbol}", h.getShip).Methods(http.MethodGet)
-	r.HandleFunc("/contracts", h.getContracts).Methods(http.MethodGet)
-	r.HandleFunc("/contracts/{contractId}", h.getContract).Methods(http.MethodGet)
-	r.HandleFunc("/contracts/{contractId}/accept", h.acceptContract).Methods(http.MethodPost)
-	r.HandleFunc("/contracts/{contractId}/fulfill", h.fulfillContract).Methods(http.MethodPost)
-	r.HandleFunc("/contracts/{contractId}/deliveries", h.recordDelivery).Methods(http.MethodPost)
-	r.HandleFunc("/contracts/{contractId}/deliveries", h.getDeliveries).Methods(http.MethodGet)
-	r.HandleFunc("/agent/{agentId}", h.getAgentById).Methods(http.MethodGet)
+	api := r.PathPrefix("/api/agent").Subrouter()
 
-	r.PathPrefix("/swagger/").Handler(httpSwagger.WrapHandler)
+	api.HandleFunc("/current-agent", h.getCurrentAgent).Methods(http.MethodGet)
+	api.HandleFunc("/agent", h.getAgent).Methods(http.MethodGet)
+	api.HandleFunc("/ships", h.getShips).Methods(http.MethodGet)
+	api.HandleFunc("/ships/{shipSymbol}", h.getShip).Methods(http.MethodGet)
+	api.HandleFunc("/contracts", h.getContracts).Methods(http.MethodGet)
+	api.HandleFunc("/contracts/{contractId}", h.getContract).Methods(http.MethodGet)
+	api.HandleFunc("/contracts/{contractId}/accept", h.acceptContract).Methods(http.MethodPost)
+	api.HandleFunc("/contracts/{contractId}/fulfill", h.fulfillContract).Methods(http.MethodPost)
+	api.HandleFunc("/contracts/{contractId}/deliveries", h.recordDelivery).Methods(http.MethodPost)
+	api.HandleFunc("/contracts/{contractId}/deliveries", h.getDeliveries).Methods(http.MethodGet)
+	api.HandleFunc("/agent/{agentId}", h.getAgentById).Methods(http.MethodGet)
+
+	api.PathPrefix("/swagger/").Handler(httpSwagger.WrapHandler)
 
 	return r
 }

--- a/src/app-runner.go
+++ b/src/app-runner.go
@@ -7,6 +7,10 @@ import (
 	"vnm/agent-info-service/db"
 )
 
+// @title Agent Info Service API
+// @version 1.0
+// @description Service for accessing information about the agent - profile, fleet, contracts.
+// @BasePath /api/agent
 func main() {
 
 	conn := db.SetUpDatabase()

--- a/src/docs/docs.go
+++ b/src/docs/docs.go
@@ -982,12 +982,12 @@ const docTemplate = `{
 
 // SwaggerInfo holds exported Swagger Info so clients can modify it
 var SwaggerInfo = &swag.Spec{
-	Version:          "",
+	Version:          "1.0",
 	Host:             "",
-	BasePath:         "",
+	BasePath:         "/api/agent",
 	Schemes:          []string{},
-	Title:            "",
-	Description:      "",
+	Title:            "Agent Info Service API",
+	Description:      "Service for accessing information about the agent - profile, fleet, contracts.",
 	InfoInstanceName: "swagger",
 	SwaggerTemplate:  docTemplate,
 	LeftDelim:        "{{",

--- a/src/docs/swagger.json
+++ b/src/docs/swagger.json
@@ -1,8 +1,12 @@
 {
     "swagger": "2.0",
     "info": {
-        "contact": {}
+        "description": "Service for accessing information about the agent - profile, fleet, contracts.",
+        "title": "Agent Info Service API",
+        "contact": {},
+        "version": "1.0"
     },
+    "basePath": "/api/agent",
     "paths": {
         "/agent": {
             "get": {

--- a/src/docs/swagger.yaml
+++ b/src/docs/swagger.yaml
@@ -1,3 +1,4 @@
+basePath: /api/agent
 definitions:
   api.CurrentAgentResponse:
     properties:
@@ -349,6 +350,10 @@ definitions:
     type: object
 info:
   contact: {}
+  description: Service for accessing information about the agent - profile, fleet,
+    contracts.
+  title: Agent Info Service API
+  version: "1.0"
 paths:
   /agent:
     get:


### PR DESCRIPTION
## Summary
- All routes moved onto a `/api/agent` PathPrefix subrouter (no handler logic changes)
- Swagger `@BasePath` annotation moved to `app-runner.go` (where `swag init -g app-runner.go` actually reads general API info) and set to `/api/agent`; docs regenerated

Part of the spacetraders.radomskyi.com deployment plan — CloudFront will route `/api/agent/*` to this service.

## Test plan
- [x] `go build ./...` passes
- [x] Rebuilt image in `meta`'s docker-compose, confirmed old bare paths (`/ships`, `/agent`) no longer resolve and `/api/agent/*` paths work
- [x] Verified end-to-end through command-interface dev server: dashboard, ship detail, cargo all load via the new prefix