### PR TITLE
Fix: actually mount routes under /api/agent

### DIFF
--- a/src/api/routes.go
+++ b/src/api/routes.go
@@ -22,7 +22,7 @@ import (
 // @title Agent Info Service API
 // @version 1.0
 // @description Service for accessing information about the agent - profile, fleet, contracts.
-// @BasePath /
+// @BasePath /api/agent
 
 type CurrentAgentResponse struct {
 	Agent     schema.Agent      `json:"agent"`
@@ -49,17 +49,19 @@ func SetUpRouter(conn *sql.DB) *mux.Router {
 	// never calls this handler, but a route has to exist here for OPTIONS to match at all.
 	r.Methods(http.MethodOptions).HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
 
-	r.HandleFunc("/current-agent", h.getCurrentAgent).Methods(http.MethodGet)
-	r.HandleFunc("/agent", h.getAgent).Methods(http.MethodGet)
-	r.HandleFunc("/ships", h.getShips).Methods(http.MethodGet)
-	r.HandleFunc("/ships/{shipSymbol}", h.getShip).Methods(http.MethodGet)
-	r.HandleFunc("/contracts", h.getContracts).Methods(http.MethodGet)
-	r.HandleFunc("/contracts/{contractId}", h.getContract).Methods(http.MethodGet)
-	r.HandleFunc("/contracts/{contractId}/accept", h.acceptContract).Methods(http.MethodPost)
-	r.HandleFunc("/contracts/{contractId}/fulfill", h.fulfillContract).Methods(http.MethodPost)
-	r.HandleFunc("/contracts/{contractId}/deliveries", h.recordDelivery).Methods(http.MethodPost)
-	r.HandleFunc("/contracts/{contractId}/deliveries", h.getDeliveries).Methods(http.MethodGet)
-	r.HandleFunc("/agent/{agentId}", h.getAgentById).Methods(http.MethodGet)
+	api := r.PathPrefix("/api/agent").Subrouter()
+
+	api.HandleFunc("/current-agent", h.getCurrentAgent).Methods(http.MethodGet)
+	api.HandleFunc("/agent", h.getAgent).Methods(http.MethodGet)
+	api.HandleFunc("/ships", h.getShips).Methods(http.MethodGet)
+	api.HandleFunc("/ships/{shipSymbol}", h.getShip).Methods(http.MethodGet)
+	api.HandleFunc("/contracts", h.getContracts).Methods(http.MethodGet)
+	api.HandleFunc("/contracts/{contractId}", h.getContract).Methods(http.MethodGet)
+	api.HandleFunc("/contracts/{contractId}/accept", h.acceptContract).Methods(http.MethodPost)
+	api.HandleFunc("/contracts/{contractId}/fulfill", h.fulfillContract).Methods(http.MethodPost)
+	api.HandleFunc("/contracts/{contractId}/deliveries", h.recordDelivery).Methods(http.MethodPost)
+	api.HandleFunc("/contracts/{contractId}/deliveries", h.getDeliveries).Methods(http.MethodGet)
+	api.HandleFunc("/agent/{agentId}", h.getAgentById).Methods(http.MethodGet)
 
 	r.PathPrefix("/swagger/").Handler(httpSwagger.WrapHandler)
 


### PR DESCRIPTION
## Summary
The route-prefix work from earlier in this project never actually landed in code - routes were still registered at root (`/ships`, `/current-agent`, etc.) despite every consumer already assuming `/api/agent/*`: command-interface's local dev config, and now the whole production CloudFront routing scheme.

Caught this during production deployment verification: CloudFront correctly forwards `/api/agent/ships` to this service, but nothing matches it. Response was 405 (not 404) because the CORS-preflight OPTIONS catch-all route has no path restriction, so it matches every path for GET too - just not the method - which is what triggers gorilla/mux's 405 instead of a "no route matched at all" 404.

## Fix
Wraps all routes in a `PathPrefix("/api/agent").Subrouter()`. No handler logic changes.

## Test plan
- [x] `go build ./...` passes
- [x] Once merged, CI auto-builds/pushes/redeploys - will verify against production directly after