### PR TITLE
Mount swagger UI under /api/agent, fix swag annotation location

### DIFF
--- a/src/api/routes.go
+++ b/src/api/routes.go
@@ -19,11 +19,6 @@ import (
 	"vnm/agent-info-service/spacetraders/schema"
 )
 
-// @title Agent Info Service API
-// @version 1.0
-// @description Service for accessing information about the agent - profile, fleet, contracts.
-// @BasePath /api/agent
-
 type CurrentAgentResponse struct {
 	Agent     schema.Agent      `json:"agent"`
 	Ships     []schema.Ship     `json:"ships"`
@@ -63,7 +58,7 @@ func SetUpRouter(conn *sql.DB) *mux.Router {
 	api.HandleFunc("/contracts/{contractId}/deliveries", h.getDeliveries).Methods(http.MethodGet)
 	api.HandleFunc("/agent/{agentId}", h.getAgentById).Methods(http.MethodGet)
 
-	r.PathPrefix("/swagger/").Handler(httpSwagger.WrapHandler)
+	api.PathPrefix("/swagger/").Handler(httpSwagger.WrapHandler)
 
 	return r
 }

--- a/src/app-runner.go
+++ b/src/app-runner.go
@@ -7,6 +7,10 @@ import (
 	"vnm/agent-info-service/db"
 )
 
+// @title Agent Info Service API
+// @version 1.0
+// @description Service for accessing information about the agent - profile, fleet, contracts.
+// @BasePath /api/agent
 func main() {
 
 	conn := db.SetUpDatabase()

--- a/src/docs/docs.go
+++ b/src/docs/docs.go
@@ -982,12 +982,12 @@ const docTemplate = `{
 
 // SwaggerInfo holds exported Swagger Info so clients can modify it
 var SwaggerInfo = &swag.Spec{
-	Version:          "",
+	Version:          "1.0",
 	Host:             "",
-	BasePath:         "",
+	BasePath:         "/api/agent",
 	Schemes:          []string{},
-	Title:            "",
-	Description:      "",
+	Title:            "Agent Info Service API",
+	Description:      "Service for accessing information about the agent - profile, fleet, contracts.",
 	InfoInstanceName: "swagger",
 	SwaggerTemplate:  docTemplate,
 	LeftDelim:        "{{",

--- a/src/docs/swagger.json
+++ b/src/docs/swagger.json
@@ -1,8 +1,12 @@
 {
     "swagger": "2.0",
     "info": {
-        "contact": {}
+        "description": "Service for accessing information about the agent - profile, fleet, contracts.",
+        "title": "Agent Info Service API",
+        "contact": {},
+        "version": "1.0"
     },
+    "basePath": "/api/agent",
     "paths": {
         "/agent": {
             "get": {

--- a/src/docs/swagger.yaml
+++ b/src/docs/swagger.yaml
@@ -1,3 +1,4 @@
+basePath: /api/agent
 definitions:
   api.CurrentAgentResponse:
     properties:
@@ -349,6 +350,10 @@ definitions:
     type: object
 info:
   contact: {}
+  description: Service for accessing information about the agent - profile, fleet,
+    contracts.
+  title: Agent Info Service API
+  version: "1.0"
 paths:
   /agent:
     get:


### PR DESCRIPTION
## Summary
- Moves the swagger UI mount from the root router to the `/api/agent`-prefixed subrouter, matching the route prefix the rest of the service already uses (landed in #5).
- Moves the `@title`/`@version`/`@description`/`@BasePath` swag annotations from `routes.go` to `app-runner.go` — the file `swag init -g app-runner.go` actually reads general API info from. Without this, the generated docs' title/description/basePath were silently blank.
- Regenerated `docs/` via `swag init -g app-runner.go -o docs --parseInternal`.
- Leftover pieces of #3, whose route-mount change had already landed separately via #5 — closing #3 as superseded, landing this here instead.

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` (no test files in this repo, nothing to run/fail)
- [x] Diffed regenerated docs against #3's version of the same files — identical