### PR TITLE
Route through st-gateway

### DIFF
--- a/src/spacetraders/client.go
+++ b/src/spacetraders/client.go
@@ -5,11 +5,19 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"os"
 
 	"vnm/agent-info-service/spacetraders/schema"
 )
 
-const BASE_URL = "https://api.spacetraders.io/v2"
+// All SpaceTraders calls route through st-gateway's shared rate budget
+// (meta#1/meta#7) instead of hitting SpaceTraders directly.
+func gatewayBaseURL() string {
+	if v := os.Getenv("ST_GATEWAY_URL"); v != "" {
+		return v + "/proxy"
+	}
+	return "http://localhost:3002/proxy"
+}
 
 func GetMyAgent(authHeader string) (schema.Agent, error) {
 	resp, err := makeAuthenticatedRequest[schema.GetMyAgentResponse](http.MethodGet, "/my/agent", authHeader, nil)
@@ -46,17 +54,25 @@ func FulfillContract(authHeader, contractId string) (schema.ContractAndAgent, er
 	return resp.Data, err
 }
 
-// makeAuthenticatedRequest forwards authHeader as-is to SpaceTraders (never stored),
-// decodes a 2xx JSON body into T, and returns an *UpstreamError for non-2xx responses
-// instead of panicking so callers (HTTP handlers) can map it to a proper status code.
+// makeAuthenticatedRequest forwards authHeader as-is through st-gateway (never
+// stored), decodes a 2xx JSON body into T, and returns an *UpstreamError for
+// non-2xx responses instead of panicking so callers (HTTP handlers) can map it
+// to a proper status code.
+//
+// Every call here is triggered by a browser request to agent-service today —
+// there is no background caller yet (that lands with automation-service's ship
+// FSMs) — so all traffic is tagged interactive. Once automation-service calls
+// agent-service directly, this needs to forward whatever priority the caller
+// declared instead of hardcoding it.
 func makeAuthenticatedRequest[T any](method, endpoint, authHeader string, body io.Reader) (T, error) {
 	var result T
 
-	req, err := http.NewRequest(method, BASE_URL+endpoint, body)
+	req, err := http.NewRequest(method, gatewayBaseURL()+endpoint, body)
 	if err != nil {
 		return result, err
 	}
 	req.Header.Set("Authorization", authHeader)
+	req.Header.Set("X-Priority", "interactive")
 	if body != nil {
 		req.Header.Set("Content-Type", "application/json")
 	}

--- a/src/spacetraders/client_test.go
+++ b/src/spacetraders/client_test.go
@@ -1,0 +1,46 @@
+package spacetraders
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+)
+
+func TestGetMyAgentRoutesThroughGatewayTaggedInteractive(t *testing.T) {
+	var gotPath, gotAuth, gotPriority string
+	fakeGateway := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotAuth = r.Header.Get("Authorization")
+		gotPriority = r.Header.Get("X-Priority")
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"data":{"symbol":"TEST-AGENT"}}`))
+	}))
+	defer fakeGateway.Close()
+
+	t.Setenv("ST_GATEWAY_URL", fakeGateway.URL)
+
+	agent, err := GetMyAgent("Bearer test-token")
+	if err != nil {
+		t.Fatalf("GetMyAgent returned error: %v", err)
+	}
+	if agent.Symbol != "TEST-AGENT" {
+		t.Errorf("expected symbol TEST-AGENT, got %q", agent.Symbol)
+	}
+	if gotPath != "/proxy/my/agent" {
+		t.Errorf("expected request to hit gateway's /proxy path, got %q", gotPath)
+	}
+	if gotAuth != "Bearer test-token" {
+		t.Errorf("expected Authorization forwarded verbatim, got %q", gotAuth)
+	}
+	if gotPriority != "interactive" {
+		t.Errorf("expected X-Priority: interactive, got %q", gotPriority)
+	}
+}
+
+func TestGatewayBaseURLDefaultsWhenUnset(t *testing.T) {
+	os.Unsetenv("ST_GATEWAY_URL")
+	if got := gatewayBaseURL(); got != "http://localhost:3002/proxy" {
+		t.Errorf("expected default gateway URL, got %q", got)
+	}
+}


### PR DESCRIPTION
Routes SpaceTraders calls through st-gateway instead of hitting the SpaceTraders API directly, tagging every request `X-Priority: interactive`.

Closes V-M-Pioneer-Trading/meta#7.